### PR TITLE
Escondendo seta nativa do `summary`

### DIFF
--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -80,7 +80,8 @@ details.details {
 		}
 	}
 
-	summary::-webkit-details-marker {
+	summary::-webkit-details-marker, summary::marker {
 		display: none;
+		color: transparent;
 	}
 }

--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -12,6 +12,10 @@
         <div class="col-md-2 col-lg-2 col-xl-2 mx-auto mb-4">
           <h6 class="text-uppercase font-weight-bold border-bottom pb-3">Temporadas</h6>
           <p>
+            <a href="https://agregador-fc-2020.netlify.app/"
+             target="_blank" rel="noopener noreferrer" class="text-white">2020</a>
+          </p>
+          <p>
             <a href="https://agregador-fc-2019.netlify.app/"
              target="_blank" rel="noopener noreferrer" class="text-white">2019</a>
           </p>


### PR DESCRIPTION
CSS `display: none` não estava funcionando no brave (chromium).
Foi resolvido configurando a cor para `transparent`.

Link para site estática da temporada 2020.